### PR TITLE
Insta url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,8 +27,8 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name instagram_url])
     # For additional in app/views/devise/registrations/edit.html.erb
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name instagram_url])
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -21,6 +21,10 @@
                     hint: "we need your current password to confirm your changes",
                     required: true,
                     input_html: { autocomplete: "current-password" } %>
+        <%= f.input :instagram_url,
+                    hint: "leave it blank if you don't add or change it",
+                    required: false,
+                    input_html: { autocomplete: "current-instagram_url" } %>
       </div>
 
       <div class="form-actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,6 +19,9 @@
         <%= f.input :password_confirmation,
                     required: true,
                     input_html: { autocomplete: "new-password" } %>
+        <%= f.input :instagram_url,
+                    required: false,
+                    input_html: { autocomplete: "instagram_url" } %>
       </div>
 
       <div class="form-actions">


### PR DESCRIPTION
Added instagram url form into signup/user-info-edit page. I confirmed that insta url info is reflected on the admin user page.

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/99185540/170913149-e00b5a0e-f2b2-408b-9c25-36c895f94282.png">

<img width="881" alt="image" src="https://user-images.githubusercontent.com/99185540/170913112-9f6da318-eab6-45d7-bae5-e8fab191a790.png">
